### PR TITLE
Python workshop: intro round, Bash-vs-Python, module slides, Python theme

### DIFF
--- a/presentations/python-netzwerk/slides.md
+++ b/presentations/python-netzwerk/slides.md
@@ -65,6 +65,10 @@ src: ./slides/00c_vergleich.md
 ---
 
 ---
+src: ./slides/00c2_bash-vs-python.md
+---
+
+---
 src: ./slides/00d_paradigmen.md
 ---
 
@@ -86,6 +90,10 @@ src: ./slides/10_section-block1.md
 
 ---
 src: ./slides/11_variablen.md
+---
+
+---
+src: ./slides/11b_sammlungen.md
 ---
 
 ---

--- a/presentations/python-netzwerk/slides.md
+++ b/presentations/python-netzwerk/slides.md
@@ -49,6 +49,26 @@ Datum: <DATUM>  ·  Trainer: <TRAINER>
 -->
 
 ---
+src: ./slides/00e_vorstellung.md
+---
+
+---
+src: ./slides/00a_wozu-python.md
+---
+
+---
+src: ./slides/00b_geschichte.md
+---
+
+---
+src: ./slides/00c_vergleich.md
+---
+
+---
+src: ./slides/00d_paradigmen.md
+---
+
+---
 src: ./slides/00_agenda.md
 ---
 
@@ -106,6 +126,14 @@ src: ./slides/40_section-block4.md
 
 ---
 src: ./slides/41_projektstruktur.md
+---
+
+---
+src: ./slides/41a_auslagern.md
+---
+
+---
+src: ./slides/41b_anatomie.md
 ---
 
 ---

--- a/presentations/python-netzwerk/slides/00_agenda.md
+++ b/presentations/python-netzwerk/slides/00_agenda.md
@@ -19,21 +19,21 @@ der ★ Profi-Bonus ist für alle, die schneller durch sind.
     <td class="t-slot-num">Start</td>
     <td class="t-time">09:00</td>
     <td class="t-arrow">→</td>
-    <td class="t-slot"><a href="/4">Ankommen, Login & Spielregeln</a></td>
+    <td class="t-slot"><a href="/8">Ankommen, Login & Spielregeln</a></td>
     <td class="t-meta">code-server</td>
   </tr>
   <tr>
     <td class="t-slot-num">Block 1</td>
     <td class="t-time">09:15</td>
     <td class="t-arrow">→</td>
-    <td class="t-slot"><a href="/5">Grundlagen & Werkzeuge</a></td>
+    <td class="t-slot"><a href="/9">Grundlagen & Werkzeuge</a></td>
     <td class="t-meta">★ Übung 1</td>
   </tr>
   <tr>
     <td class="t-slot-num">Block 2</td>
     <td class="t-time">10:15</td>
     <td class="t-arrow">→</td>
-    <td class="t-slot"><a href="/7">Kontrollfluss</a></td>
+    <td class="t-slot"><a href="/11">Kontrollfluss</a></td>
     <td class="t-meta">★ Übung 2</td>
   </tr>
   <tr class="is-break">
@@ -47,7 +47,7 @@ der ★ Profi-Bonus ist für alle, die schneller durch sind.
     <td class="t-slot-num">Block 3</td>
     <td class="t-time">11:15</td>
     <td class="t-arrow">→</td>
-    <td class="t-slot"><a href="/10">Funktionen — das Herzstück</a></td>
+    <td class="t-slot"><a href="/14">Funktionen — das Herzstück</a></td>
     <td class="t-meta">★ Übung 3</td>
   </tr>
   <tr class="is-break">
@@ -61,7 +61,7 @@ der ★ Profi-Bonus ist für alle, die schneller durch sind.
     <td class="t-slot-num">Block 4</td>
     <td class="t-time">13:30</td>
     <td class="t-arrow">→</td>
-    <td class="t-slot"><a href="/14">Projekt organisieren — Module & venv</a></td>
+    <td class="t-slot"><a href="/18">Projekt organisieren — Module & venv</a></td>
     <td class="t-meta">★ Übung 4</td>
   </tr>
   <tr class="is-break">
@@ -75,14 +75,14 @@ der ★ Profi-Bonus ist für alle, die schneller durch sind.
     <td class="t-slot-num">Block 5</td>
     <td class="t-time">15:00</td>
     <td class="t-arrow">→</td>
-    <td class="t-slot"><a href="/18">Bibliotheken, APIs & Debugging</a></td>
+    <td class="t-slot"><a href="/22">Bibliotheken, APIs & Debugging</a></td>
     <td class="t-meta">★ Übung 5</td>
   </tr>
   <tr>
     <td class="t-slot-num">Ende</td>
     <td class="t-time">16:15</td>
     <td class="t-arrow">→</td>
-    <td class="t-slot"><a href="/23">Spickzettel, Ausblick & Q&A</a></td>
+    <td class="t-slot"><a href="/27">Spickzettel, Ausblick & Q&A</a></td>
     <td class="t-meta">bis 16:30</td>
   </tr>
 </table>

--- a/presentations/python-netzwerk/slides/00a_wozu-python.md
+++ b/presentations/python-netzwerk/slides/00a_wozu-python.md
@@ -1,0 +1,62 @@
+---
+layout: default
+num: 'Wozu Python?'
+meta: 'Warum diese Sprache · wo Python stark ist'
+---
+
+<div class="page-label">Warum Python</div>
+
+# Wozu <span class="accent">Python</span> — und warum gerade ihr<span class="dot">.</span>
+
+<p class="lede">
+Python ist die Sprache fürs Automatisieren: lesbar, schnell zu schreiben und für fast jede
+Aufgabe gibt es schon eine fertige Bibliothek. Genau das passt zum Netzwerk-Alltag.
+</p>
+
+<div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 24px; margin-top: 32px;">
+
+  <div class="surface" v-click style="padding: 26px 30px;">
+    <div class="mono accent" style="font-size: 15px; letter-spacing: 0.14em;">NETZWERK</div>
+    <div style="font-size: 22px; font-weight: 600; margin-top: 10px;">Geräte & Automatisierung</div>
+    <ul style="margin: 14px 0 0; padding: 0; list-style: none; display: grid; gap: 9px; font-size: 18px; line-height: 1.4;">
+      <li>· Konfigs erzeugen & ausrollen</li>
+      <li>· <span class="mono">Netmiko</span>, <span class="mono">NAPALM</span>, <span class="mono">Nornir</span></li>
+      <li>· Ansible ist in Python gebaut</li>
+    </ul>
+  </div>
+
+  <div class="surface" v-click style="padding: 26px 30px;">
+    <div class="mono accent" style="font-size: 15px; letter-spacing: 0.14em;">BETRIEB</div>
+    <div style="font-size: 22px; font-weight: 600; margin-top: 10px;">Skripte & APIs</div>
+    <ul style="margin: 14px 0 0; padding: 0; list-style: none; display: grid; gap: 9px; font-size: 18px; line-height: 1.4;">
+      <li>· Handarbeit wegautomatisieren</li>
+      <li>· REST-APIs abfragen (<span class="mono">requests</span>)</li>
+      <li>· Monitoring & Reports</li>
+    </ul>
+  </div>
+
+  <div class="surface" v-click style="padding: 26px 30px;">
+    <div class="mono accent" style="font-size: 15px; letter-spacing: 0.14em;">WEIT VERBREITET</div>
+    <div style="font-size: 22px; font-weight: 600; margin-top: 10px;">Überall im Einsatz</div>
+    <ul style="margin: 14px 0 0; padding: 0; list-style: none; display: grid; gap: 9px; font-size: 18px; line-height: 1.4;">
+      <li>· DevOps & Cloud</li>
+      <li>· Datenauswertung</li>
+      <li>· KI / Machine Learning</li>
+    </ul>
+  </div>
+
+</div>
+
+<div class="mantra" style="margin-top: 30px;">
+  <div class="label">Kernidee</div>
+  <div class="text">Python ist heute eine der meistgenutzten Sprachen der Welt — weil man damit schnell etwas Nützliches gebaut bekommt, ohne Informatik-Studium.</div>
+</div>
+
+<!--
+Motivierender Einstieg vor der Agenda. Holt die Gruppe ab: Warum lernen wir gerade Python und
+nicht etwas anderes? Antwort: Es ist die De-facto-Sprache für Automatisierung und für unseren
+Netzwerk-Alltag direkt anschlussfähig — Netmiko/NAPALM/Nornir reden mit Geräten, Ansible selbst
+ist in Python geschrieben. Gleichzeitig ist Python weit über das Netzwerk hinaus verbreitet
+(DevOps, Cloud, Datenauswertung, KI), das gelernte Wissen ist also überall einsetzbar.
+Betone die Lesbarkeit und die riesige Bibliotheks-Auswahl (PyPI) als die zwei Hauptgründe.
+-->

--- a/presentations/python-netzwerk/slides/00b_geschichte.md
+++ b/presentations/python-netzwerk/slides/00b_geschichte.md
@@ -1,0 +1,64 @@
+---
+layout: default
+num: 'Geschichte'
+meta: 'Eine kurze Geschichte von Python · 1991 bis heute'
+---
+
+<div class="page-label">Eine kurze Geschichte</div>
+
+# Von einem <span class="accent">Weihnachtsprojekt</span> zur Weltsprache<span class="dot">.</span>
+
+<p class="lede">
+Python ist über 30 Jahre alt — und genau diese Reife macht es heute so stabil, gut
+dokumentiert und reich an Bibliotheken.
+</p>
+
+<div style="position: relative; margin: 64px 8px 0;">
+<div style="position: absolute; top: 13px; left: 0; right: 0; height: 3px; background: linear-gradient(90deg, var(--accent, #2563eb) 0%, var(--accent, #2563eb) 70%, var(--fg-muted, #94a3b8) 100%); border-radius: 2px;"></div>
+<div style="display: grid; grid-template-columns: repeat(5, 1fr); gap: 18px;">
+<div v-click style="position: relative; padding-top: 44px; text-align: center;">
+<div style="position: absolute; top: 5px; left: 50%; transform: translateX(-50%); width: 18px; height: 18px; border-radius: 50%; background: var(--accent, #2563eb); box-shadow: 0 0 0 5px rgba(37,99,235,0.15);"></div>
+<div class="mono accent" style="font-size: 30px; font-weight: 700; letter-spacing: 0.02em;">1991</div>
+<div style="font-size: 19px; font-weight: 600; margin-top: 8px; line-height: 1.3;">Erste Version von <strong>Guido van Rossum</strong></div>
+<div class="muted" style="font-size: 16px; margin-top: 6px;">Name: Monty Python</div>
+</div>
+<div v-click style="position: relative; padding-top: 44px; text-align: center;">
+<div style="position: absolute; top: 5px; left: 50%; transform: translateX(-50%); width: 18px; height: 18px; border-radius: 50%; background: var(--accent, #2563eb); box-shadow: 0 0 0 5px rgba(37,99,235,0.15);"></div>
+<div class="mono accent" style="font-size: 30px; font-weight: 700; letter-spacing: 0.02em;">2000</div>
+<div style="font-size: 19px; font-weight: 600; margin-top: 8px; line-height: 1.3;">Python <strong>2.0</strong> — Community wächst</div>
+<div class="muted" style="font-size: 16px; margin-top: 6px;">Open Source</div>
+</div>
+<div v-click style="position: relative; padding-top: 44px; text-align: center;">
+<div style="position: absolute; top: 5px; left: 50%; transform: translateX(-50%); width: 18px; height: 18px; border-radius: 50%; background: var(--accent, #2563eb); box-shadow: 0 0 0 5px rgba(37,99,235,0.15);"></div>
+<div class="mono accent" style="font-size: 30px; font-weight: 700; letter-spacing: 0.02em;">2008</div>
+<div style="font-size: 19px; font-weight: 600; margin-top: 8px; line-height: 1.3;">Python <strong>3.0</strong> — der große Schnitt</div>
+<div class="muted" style="font-size: 16px; margin-top: 6px;">nicht abwärts­kompatibel</div>
+</div>
+<div v-click style="position: relative; padding-top: 44px; text-align: center;">
+<div style="position: absolute; top: 5px; left: 50%; transform: translateX(-50%); width: 18px; height: 18px; border-radius: 50%; background: var(--accent, #2563eb); box-shadow: 0 0 0 5px rgba(37,99,235,0.15);"></div>
+<div class="mono accent" style="font-size: 30px; font-weight: 700; letter-spacing: 0.02em;">2020</div>
+<div style="font-size: 19px; font-weight: 600; margin-top: 8px; line-height: 1.3;">Python <strong>2 abgeschaltet</strong> (EOL)</div>
+<div class="muted" style="font-size: 16px; margin-top: 6px;">nur noch Python 3</div>
+</div>
+<div v-click style="position: relative; padding-top: 44px; text-align: center;">
+<div style="position: absolute; top: 3px; left: 50%; transform: translateX(-50%); width: 22px; height: 22px; border-radius: 50%; background: #fff; border: 4px solid var(--accent, #2563eb); box-shadow: 0 0 0 5px rgba(37,99,235,0.15);"></div>
+<div class="mono accent" style="font-size: 30px; font-weight: 700; letter-spacing: 0.02em;">heute</div>
+<div style="font-size: 19px; font-weight: 600; margin-top: 8px; line-height: 1.3;">Eine der <strong>meistgenutzten Sprachen</strong></div>
+<div class="muted" style="font-size: 16px; margin-top: 6px;">Version 3.x</div>
+</div>
+</div>
+</div>
+
+<div class="mantra" style="margin-top: 28px;">
+  <div class="label">Wichtig für heute</div>
+  <div class="text">Wir nutzen ausschließlich <span class="mono">Python 3</span>. Code-Beispiele aus dem Netz mit <span class="mono">print "..."</span> (ohne Klammern) sind altes Python 2 — Finger weg.</div>
+</div>
+
+<!--
+Kurzer historischer Kontext, hält nicht lange auf. Erzähl die Anekdote: Guido van Rossum begann
+das Projekt 1989/1990 in der Weihnachtszeit als Hobby; der Name kommt von der Comedy-Truppe
+„Monty Python", nicht von der Schlange. Wichtigster praktischer Punkt: Es gab einen harten Bruch
+zwischen Python 2 und 3. Python 2 ist seit 2020 offiziell tot. Deshalb der Hinweis unten — wenn
+man im Netz Beispiele findet, an `print` ohne Klammern erkennt man veralteten Python-2-Code.
+Wir arbeiten heute durchgängig mit Python 3.
+-->

--- a/presentations/python-netzwerk/slides/00c2_bash-vs-python.md
+++ b/presentations/python-netzwerk/slides/00c2_bash-vs-python.md
@@ -1,0 +1,80 @@
+---
+layout: default
+num: 'Bash vs. Python'
+meta: 'Dieselbe Aufgabe · zwei Sprachen · wann was'
+---
+
+<div class="page-label">Bash vs. Python</div>
+
+# Wann <span class="accent">Bash</span> aufhört, Spaß zu machen<span class="dot">.</span>
+
+<p class="lede" style="margin-top: 10px; max-width: 88ch;">
+Aufgabe: Aus der JSON-Antwort einer Geräte-API alle Geräte mit <strong>CPU-Last über 80 %</strong>
+herausfiltern — und sauber abbrechen, wenn die API einen Fehler liefert.
+</p>
+
+<div class="vn">
+
+  <div class="vn-col">
+    <div class="vn-tag bash">Bash · schnell am Limit</div>
+
+```bash
+resp=$(curl -s http://api/devices)
+
+# JSON von Hand? Nur mit jq erträglich —
+# Zahlenvergleich, verschachtelte Felder:
+echo "$resp" | jq -r '.devices[]
+  | select(.cpu > 0.8) | .name'
+
+# kein Fehler-Handling (HTTP 500?),
+# schwer erweiterbar, nicht auf Windows
+```
+
+  </div>
+
+  <div class="vn-col" v-click>
+    <div class="vn-tag python">Python · wächst mit</div>
+
+```python
+import requests
+
+resp = requests.get("http://api/devices", timeout=10)
+resp.raise_for_status()        # scheitert sauber bei HTTP-Fehler
+
+for dev in resp.json()["devices"]:
+    if dev["cpu"] > 0.8:       # echter Zahlenvergleich
+        print(dev["name"])
+# lesbar · typsicher · testbar · überall lauffähig
+```
+
+  </div>
+
+</div>
+
+<div class="mantra" style="margin-top: 22px;">
+  <div class="label">Faustregel</div>
+  <div class="text">Für Einzeiler ist Bash unschlagbar. Sobald <strong>Logik, Zahlen, JSON oder Fehlerbehandlung</strong> dazukommen, ist Python die klarere Wahl.</div>
+</div>
+
+<style scoped>
+.vn { display: grid; grid-template-columns: 1fr 1fr; gap: 30px; margin-top: 22px; align-items: start; }
+.vn-tag { font-family: var(--font-mono); font-size: 15px; font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase; margin-bottom: 12px; }
+.vn-tag.bash   { color: #C0392B; }
+.vn-tag.python { color: var(--accent); }
+.vn .slidev-code { font-size: 18px !important; padding: 22px !important; }
+</style>
+
+<!--
+Diese Slide macht die abstrakte Aussage der Vergleichs-Folie („mächtiger als ein Shell-Skript")
+konkret — und zwar an einer Aufgabe aus dem echten Netzwerk-Alltag, die genau zu Block 5 passt
+(REST-API + JSON). WICHTIG: kein Bash-Bashing. Betone, dass Bash für Einzeiler und das Verketten
+von Befehlen unschlagbar ist. Links zeigen wir die faire, realistische Bash-Lösung MIT jq — und
+trotzdem sieht man die Schwächen: JSON und Zahlenvergleiche sind fummelig, es gibt kein sauberes
+Fehler-Handling (was, wenn die API HTTP 500 liefert oder leer antwortet?), und sobald die Logik
+wächst (zwei Bedingungen, Daten zusammenführen, sortieren) explodiert die Lesbarkeit. Rechts per
+Klick die Python-Variante aufdecken: requests holt die Daten, raise_for_status bricht bei Fehlern
+sauber ab, der Vergleich ist ein echter Zahlenvergleich, die Struktur liest sich wie Prosa. Und:
+läuft identisch auf Windows/Linux/macOS. Kernbotschaft = die Faustregel unten. Das ist der
+Motivations-Haken für einen Raum voller Leute, die Bash schon können: Python ist der nächste
+logische Schritt, kein Bruch.
+-->

--- a/presentations/python-netzwerk/slides/00c_vergleich.md
+++ b/presentations/python-netzwerk/slides/00c_vergleich.md
@@ -1,0 +1,80 @@
+---
+layout: default
+num: 'Im Vergleich'
+meta: 'Python neben Bash, Go, JavaScript & C'
+---
+
+<div class="page-label">Python im Vergleich</div>
+
+# Welche Sprache <span class="accent">wofür</span><span class="dot">.</span>
+
+<p class="lede">
+Jede Sprache hat ihren Sweet Spot. Python liegt im goldenen Mittelweg: viel mächtiger als ein
+Shell-Skript, aber deutlich einfacher zu schreiben als Go, Java oder C.
+</p>
+
+<table class="agenda" style="margin-top: 22px;">
+  <tr style="opacity: 0.55; font-size: 15px; text-transform: uppercase; letter-spacing: 0.08em;">
+    <td class="t-slot">Sprache</td>
+    <td class="t-time">Jahr</td>
+    <td class="t-slot">Von</td>
+    <td class="t-slot">Typischer Einsatz</td>
+    <td class="t-meta">Stärke / Schwäche</td>
+  </tr>
+  <tr>
+    <td class="t-slot" style="font-weight: 600;"><span class="mono accent">Python</span></td>
+    <td class="t-time">1991</td>
+    <td class="t-slot">Guido van Rossum</td>
+    <td class="t-slot">Automatisierung, APIs, Datenauswertung, KI</td>
+    <td class="t-meta">lesbar, riesige Bibliothek</td>
+  </tr>
+  <tr>
+    <td class="t-slot" style="font-weight: 600;"><span class="mono">Bash</span></td>
+    <td class="t-time">1989</td>
+    <td class="t-slot">Brian Fox · GNU</td>
+    <td class="t-slot">Kurze Einzeiler, Dateien & Befehle verketten</td>
+    <td class="t-meta">stark im Terminal, schnell unübersichtlich</td>
+  </tr>
+  <tr>
+    <td class="t-slot" style="font-weight: 600;"><span class="mono">Go</span></td>
+    <td class="t-time">2009</td>
+    <td class="t-slot">Google</td>
+    <td class="t-slot">Schnelle CLI-Tools, Netzwerk-Services</td>
+    <td class="t-meta">sehr schnell, eine fertige Binärdatei</td>
+  </tr>
+  <tr>
+    <td class="t-slot" style="font-weight: 600;"><span class="mono">JavaScript</span></td>
+    <td class="t-time">1995</td>
+    <td class="t-slot">Brendan Eich · Netscape</td>
+    <td class="t-slot">Web-Oberflächen, Browser & Frontend</td>
+    <td class="t-meta">Sprache des Webs</td>
+  </tr>
+  <tr>
+    <td class="t-slot" style="font-weight: 600;"><span class="mono">C / C++</span></td>
+    <td class="t-time">1972 / 85</td>
+    <td class="t-slot">Ritchie · Stroustrup</td>
+    <td class="t-slot">Systemnahes, maximale Performance</td>
+    <td class="t-meta">mächtig, aber aufwändig & fehleranfällig</td>
+  </tr>
+</table>
+
+<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 24px; margin-top: 28px;">
+  <div class="mantra" style="margin: 0;">
+    <div class="label">Python ist…</div>
+    <div class="text">interpretiert (kein Kompilieren), dynamisch typisiert (Typ ergibt sich aus dem Wert) und auf Lesbarkeit getrimmt.</div>
+  </div>
+  <div class="mantra" style="margin: 0;">
+    <div class="label">Faustregel</div>
+    <div class="text">Zu viel für Bash, aber kein Hochleistungs-Dienst? → Python ist fast immer die richtige Wahl.</div>
+  </div>
+</div>
+
+<!--
+Einordnung, keine Glaubensdiskussion. Ziel: Die Gruppe versteht, WANN Python die richtige Wahl
+ist. Bash kennen viele aus dem Netzwerk-Alltag — super für Einzeiler, wird aber bei echter Logik
+(Schleifen, Fehlerbehandlung, Datenstrukturen) schnell unleserlich. Genau da setzt Python an.
+Go und C sind kompiliert und schneller, aber für unsere Automatisierungs-Aufgaben Overkill.
+Die zwei Begriffe unten kurz erklären: „interpretiert" = wir führen den Code direkt aus, kein
+extra Übersetzungsschritt; „dynamisch typisiert" = wir schreiben nicht hin, ob etwas Text oder
+Zahl ist, Python merkt es selbst (Anknüpfung an die Variablen-Folie später). Faustregel betonen.
+-->

--- a/presentations/python-netzwerk/slides/00d_paradigmen.md
+++ b/presentations/python-netzwerk/slides/00d_paradigmen.md
@@ -1,0 +1,62 @@
+---
+layout: default
+num: 'Paradigmen'
+meta: 'Prozedural · objektorientiert · funktional · async'
+---
+
+<div class="page-label">Mehr als nur Skripte</div>
+
+# Python lässt dir <span class="accent">die Wahl</span><span class="dot">.</span>
+
+<p class="lede">
+Python ist <strong>multi-paradigmatisch</strong>: Du kannst simpel Schritt für Schritt skripten —
+oder mit Klassen, funktionalem Stil und Nebenläufigkeit arbeiten. Alles in derselben Sprache.
+</p>
+
+<div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 22px; margin-top: 28px;">
+
+  <div class="surface" v-click style="padding: 24px 28px;">
+    <div class="mono accent" style="font-size: 15px; letter-spacing: 0.14em;">PROZEDURAL</div>
+    <div style="font-size: 21px; font-weight: 600; margin-top: 8px;">Schritt für Schritt</div>
+    <div class="muted" style="font-size: 17px; margin-top: 6px;">Das machen wir heute — einfache, lesbare Skripte.</div>
+    <div class="mono" style="font-size: 16px; margin-top: 10px;">for host in hosts: ping(host)</div>
+  </div>
+
+  <div class="surface" v-click style="padding: 24px 28px;">
+    <div class="mono accent" style="font-size: 15px; letter-spacing: 0.14em;">OBJEKTORIENTIERT</div>
+    <div style="font-size: 21px; font-weight: 600; margin-top: 8px;">Ja — voll OOP</div>
+    <div class="muted" style="font-size: 17px; margin-top: 6px;"><em>Alles</em> ist ein Objekt: Klassen, Vererbung, Methoden.</div>
+    <div class="mono" style="font-size: 16px; margin-top: 10px;">class Router: ...&nbsp;&nbsp;r.reboot()</div>
+  </div>
+
+  <div class="surface" v-click style="padding: 24px 28px;">
+    <div class="mono accent" style="font-size: 15px; letter-spacing: 0.14em;">FUNKTIONAL</div>
+    <div style="font-size: 21px; font-weight: 600; margin-top: 8px;">Kompakt & elegant</div>
+    <div class="muted" style="font-size: 17px; margin-top: 6px;">Comprehensions, <span class="mono">map</span>, <span class="mono">filter</span>, <span class="mono">lambda</span>.</div>
+    <div class="mono" style="font-size: 16px; margin-top: 10px;">[ip for ip in netz if aktiv(ip)]</div>
+  </div>
+
+  <div class="surface" v-click style="padding: 24px 28px;">
+    <div class="mono accent" style="font-size: 15px; letter-spacing: 0.14em;">ASYNC</div>
+    <div style="font-size: 21px; font-weight: 600; margin-top: 8px;">Vieles gleichzeitig</div>
+    <div class="muted" style="font-size: 17px; margin-top: 6px;"><span class="mono">async/await</span> seit 3.5 — 100 Hosts parallel abfragen.</div>
+    <div class="mono" style="font-size: 16px; margin-top: 10px;">await check(host)</div>
+  </div>
+
+</div>
+
+<div class="mantra" style="margin-top: 26px;">
+  <div class="label">Für heute</div>
+  <div class="text">Wir bleiben bewusst beim <strong>prozeduralen</strong> Stil — der reicht für 90 % des Netzwerk-Alltags. Die anderen drei sind da, wenn ihr sie irgendwann braucht.</div>
+</div>
+
+<!--
+Diese Folie nimmt eine häufige Einsteiger-Frage vorweg: „Ist Python objektorientiert oder nicht?"
+Antwort: beides — und mehr. Python zwingt kein Paradigma auf. Intern ist alles ein Objekt (auch
+ints und Funktionen), volle OOP mit Klassen und Vererbung ist vorhanden. Gleichzeitig kann man
+rein prozedural skripten (so machen wir es heute) oder funktional arbeiten (Comprehensions sind
+sehr „pythonic"). Async/await (seit Python 3.5) ist der Joker für Netzwerk-Aufgaben: viele
+langsame I/O-Operationen — z. B. 100 Geräte abfragen — laufen nebenläufig statt nacheinander.
+Wichtig zu betonen: Für den Workshop brauchen sie davon NICHTS außer dem prozeduralen Stil.
+Das hier ist ein „gut zu wissen, wie weit man kommen kann"-Ausblick, kein Lernstoff für heute.
+-->

--- a/presentations/python-netzwerk/slides/00e_vorstellung.md
+++ b/presentations/python-netzwerk/slides/00e_vorstellung.md
@@ -1,0 +1,60 @@
+---
+layout: default
+num: '00 · Vorstellungsrunde'
+meta: 'Ankommen · kurze Runde · ~1 Minute pro Person'
+---
+
+<div class="page-label">00 · Vorstellungsrunde</div>
+
+# Kurz <span class="accent">kennenlernen</span><span class="dot">.</span>
+
+<p class="lede" style="margin-top: 14px; max-width: 82ch;">
+Reihum, ca. eine Minute pro Person — damit wir wissen, wer mit am Tisch sitzt und
+den Tag auf euch abstimmen können.
+</p>
+
+<div style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 22px; margin-top: 30px;">
+
+  <div class="surface" style="padding: 26px 28px;">
+    <div class="mono accent" style="font-size: 30px; font-weight: 700;">01</div>
+    <div style="font-size: 22px; font-weight: 600; margin-top: 10px;">Wer bist du?</div>
+    <p style="font-size: 18px; line-height: 1.45; margin-top: 10px;">Name &amp; deine Rolle im Netzwerkteam.</p>
+  </div>
+
+  <div class="surface" style="padding: 26px 28px;">
+    <div class="mono accent" style="font-size: 30px; font-weight: 700;">02</div>
+    <div style="font-size: 22px; font-weight: 600; margin-top: 10px;">Schon mal Code?</div>
+    <p style="font-size: 18px; line-height: 1.45; margin-top: 10px;">Python, Bash, ein bisschen Skripting — oder ganz frisch dabei?</p>
+  </div>
+
+  <div class="surface" style="padding: 26px 28px;">
+    <div class="mono accent" style="font-size: 30px; font-weight: 700;">03</div>
+    <div style="font-size: 22px; font-weight: 600; margin-top: 10px;">Dein Klassiker</div>
+    <p style="font-size: 18px; line-height: 1.45; margin-top: 10px;">Eine wiederkehrende Aufgabe, die du gern automatisieren würdest.</p>
+  </div>
+
+  <div class="surface" style="padding: 26px 28px;">
+    <div class="mono accent" style="font-size: 30px; font-weight: 700;">04</div>
+    <div style="font-size: 22px; font-weight: 600; margin-top: 10px;">Dein Ziel heute</div>
+    <p style="font-size: 18px; line-height: 1.45; margin-top: 10px;">Was möchtest du am Abend mitnehmen?</p>
+  </div>
+
+</div>
+
+<div class="mantra" style="margin-top: 30px;">
+  <div class="label">Kein Druck</div>
+  <div class="text">Vorkenntnisse sind <strong>keine</strong> Voraussetzung — die Runde hilft uns nur, Tempo und Beispiele passend zu wählen.</div>
+</div>
+
+<!--
+Diese Runde ist bewusst kurz — als Trainer machst du den Anfang und gibst damit das Format vor:
+Name, Rolle, Vorerfahrung, ein Automatisierungs-Wunsch, ein Ziel für heute. Halte pro Person
+grob eine Minute, bei größeren Gruppen (>8) nur Name + Vorerfahrung + Ziel abfragen, sonst
+sprengt es den Zeitplan. Punkt 03 (der „Klassiker", den man automatisieren würde) ist Gold:
+notier dir die Antworten — daraus lassen sich über den Tag konkrete Bezüge herstellen
+(„genau dafür ist Übung 2 / die API in Block 5 gedacht"). Punkt 02 ersetzt den Handzeichen-
+Skill-Check von der Agenda-Slide; wenn du beides machst, hier nur kurz halten. Wichtigste
+Botschaft am Ende: fehlende Vorkenntnisse sind völlig okay, der Tag ist für Einsteiger gebaut.
+Namen der Co-Coaches (Stefan, Adrian) kommen gleich auf der Login-Slide — hier nur die
+Teilnehmenden.
+-->

--- a/presentations/python-netzwerk/slides/11_variablen.md
+++ b/presentations/python-netzwerk/slides/11_variablen.md
@@ -1,58 +1,53 @@
 ---
 layout: default
-num: '06 · Variablen & Datentypen'
-meta: 'Block 1 · 01_grundlagen.py'
+num: '06 · Einzelwerte'
+meta: 'Block 1 · 01_grundlagen.py · str · int · float · bool'
 ---
 
-<div class="page-label">Block 1 · Variablen & Datentypen</div>
+<div class="page-label">Block 1 · Variablen & Datentypen (1/2)</div>
 
-# Sechs Bausteine, mehr <span class="accent">braucht's erstmal nicht</span><span class="dot">.</span>
+# Vier Werte — und Python <span class="accent">kennt den Typ selbst</span><span class="dot">.</span>
 
-<div style="display: grid; grid-template-columns: 0.85fr 1.15fr; gap: 40px; margin-top: 24px; align-items: start;">
+<div style="display: grid; grid-template-columns: 0.72fr 1.28fr; gap: 44px; margin-top: 26px; align-items: start;">
 
 <div>
-<ul style="margin: 0; padding: 0; list-style: none; display: grid; gap: 14px; font-size: 23px; line-height: 1.35;">
+<ul style="margin: 0; padding: 0; list-style: none; display: grid; gap: 18px; font-size: 25px; line-height: 1.35;">
   <li><span class="mono accent">str</span> &nbsp;Text — <span class="muted">Hostname</span></li>
   <li><span class="mono accent">int</span> &nbsp;Ganzzahl — <span class="muted">Port-Anzahl</span></li>
   <li><span class="mono accent">float</span> &nbsp;Kommazahl — <span class="muted">CPU-Last</span></li>
   <li><span class="mono accent">bool</span> &nbsp;<span class="mono">True/False</span> — <span class="muted">online?</span></li>
-  <li><span class="mono accent">list</span> &nbsp;Reihenfolge — <span class="muted">Geräteliste</span></li>
-  <li><span class="mono accent">dict</span> &nbsp;Schlüssel→Wert — <span class="muted">Host→IP</span></li>
 </ul>
 
-<div class="mantra" style="margin-top: 26px;">
+<div class="mantra" style="margin-top: 28px;">
   <div class="label">f-string</div>
-  <div class="text"><span class="mono">f"...{variable}..."</span> setzt Werte direkt in den Text ein.</div>
+  <div class="text"><span class="mono">f"...{variable}..."</span> setzt Werte direkt in den Text ein — auch Rechnungen.</div>
 </div>
 </div>
 
-```python {1-4|6-9|11|12|14-15|all}
-hostname   = "router-stuttgart-01"   # str
-port_count = 48                      # int
-cpu_load   = 0.41                    # float
-is_online  = True                    # bool
+```python {1-4|6-9|8|all}
+hostname   = "router-stuttgart-01"   # str   · Text
+port_count = 48                      # int   · Ganzzahl
+cpu_load   = 0.41                    # float · Kommazahl
+is_online  = True                    # bool  · True/False
 
 print("=== Geräte-Info ===")
 print(f"Hostname : {hostname}")
 print(f"CPU-Last : {cpu_load * 100:.0f} %")
 print(f"Online   : {is_online}")
-
-hosts = ["sw-01", "sw-02", "fw-01", "rtr-01"]      # list
-ip_of = {"sw-01": "10.0.1.11", "sw-02": "10.0.1.12"}  # dict
-
-print(f"Wir verwalten {len(hosts)} Geräte")
-print(f"IP von sw-02: {ip_of['sw-02']}")
 ```
 
 </div>
 
+<style scoped>
+.slidev-code { font-size: 26px !important; line-height: 1.6 !important; padding: 32px !important; }
+</style>
+
 <!--
-Das ist der Code aus 01_grundlagen.py. Geht die Highlights Schritt für Schritt durch:
-Erst die vier Einzelwerte (str/int/float/bool) — betont, dass man den Typ NICHT deklariert,
-Python erkennt ihn am Wert. Dann die print-Zeilen mit f-strings: der Ausdruck in den
-geschweiften Klammern wird ausgewertet, auch Rechnungen wie cpu_load * 100. Dann die list
-(geordnete Sammlung, mit len() zählbar) und das dict (Nachschlagen über den Schlüssel,
-ip_of['sw-02']). Tipp für die REPL-vs-Skript-Frage: man kann jede Zeile auch interaktiv im
-Python-Prompt ausprobieren (python eingeben, Enter) — zum Lernen super, für echte Programme
-schreibt man sie aber in eine .py-Datei und führt sie als Ganzes aus.
+Erste von zwei Datentyp-Slides — hier nur die vier Einzelwerte, damit der Code groß und lesbar
+ist. Kernbotschaft: man deklariert den Typ NICHT, Python erkennt ihn am Wert (dynamisch typisiert,
+Anknüpfung an die Vergleichs-Folie). Highlights durchgehen: erst die vier Zuweisungen, dann die
+print-Zeilen mit f-strings. Betone bei Zeile 8, dass in den geschweiften Klammern ein echter
+Ausdruck steht — cpu_load * 100 wird gerechnet, :.0f rundet auf ganze Prozent. REPL-Tipp: jede
+Zeile lässt sich auch interaktiv im python-Prompt ausprobieren; für echte Programme aber in eine
+.py-Datei schreiben und als Ganzes ausführen. Sammlungen (list/dict) kommen auf der nächsten Slide.
 -->

--- a/presentations/python-netzwerk/slides/11b_sammlungen.md
+++ b/presentations/python-netzwerk/slides/11b_sammlungen.md
@@ -1,0 +1,53 @@
+---
+layout: default
+num: '06 · Sammlungen'
+meta: 'Block 1 · 01_grundlagen.py · list · dict'
+---
+
+<div class="page-label">Block 1 · Variablen & Datentypen (2/2)</div>
+
+# Viele Werte auf einmal: <span class="accent">list</span> &amp; <span class="accent">dict</span><span class="dot">.</span>
+
+<div style="display: grid; grid-template-columns: 0.72fr 1.28fr; gap: 44px; margin-top: 26px; align-items: start;">
+
+<div>
+<ul style="margin: 0; padding: 0; list-style: none; display: grid; gap: 20px; font-size: 25px; line-height: 1.35;">
+  <li><span class="mono accent">list</span> &nbsp;geordnete Reihe<br/><span class="muted" style="font-size: 20px;">Geräteliste — mit <span class="mono">len()</span> zählbar</span></li>
+  <li><span class="mono accent">dict</span> &nbsp;Schlüssel → Wert<br/><span class="muted" style="font-size: 20px;">Host → IP — Nachschlagen per Schlüssel</span></li>
+</ul>
+
+<div class="mantra" style="margin-top: 28px;">
+  <div class="label">Zugriff</div>
+  <div class="text"><span class="mono">hosts[0]</span> über Position · <span class="mono">ip_of["sw-02"]</span> über Schlüssel.</div>
+</div>
+</div>
+
+```python {1|3-7|9|10|all}
+hosts = ["sw-01", "sw-02", "fw-01", "rtr-01"]   # list
+
+ip_of = {                                        # dict
+    "sw-01": "10.0.1.11",
+    "sw-02": "10.0.1.12",
+    "fw-01": "10.0.0.1",
+}
+
+print(f"Wir verwalten {len(hosts)} Geräte")
+print(f"IP von sw-02: {ip_of['sw-02']}")
+```
+
+</div>
+
+<style scoped>
+.slidev-code { font-size: 26px !important; line-height: 1.6 !important; padding: 32px !important; }
+</style>
+
+<!--
+Zweite Datentyp-Slide: die beiden Sammlungen. list = geordnete Reihe von Werten, Zugriff über die
+Position (hosts[0] ist das erste Element, Zählung ab 0!), Länge mit len(). dict = Nachschlage-
+tabelle aus Schlüssel-Wert-Paaren, Zugriff über den Schlüssel (ip_of["sw-02"]). Genau diese beiden
+Strukturen brauchen sie gleich in Übung 1 (Dictionary-Eintrag ergänzen) und immer wieder — eine
+API-Antwort ist am Ende auch nur ein dict aus Listen und dicts. Highlights: erst die Liste, dann
+das dict über mehrere Zeilen (gut lesbar, ein Paar pro Zeile), dann len() und der Schlüsselzugriff.
+Auf das Detail hinweisen: im f-string die Anführungszeichen des Schlüssels anders setzen als die
+des Strings (hier ' innen, " außen), sonst Syntaxfehler.
+-->

--- a/presentations/python-netzwerk/slides/41a_auslagern.md
+++ b/presentations/python-netzwerk/slides/41a_auslagern.md
@@ -1,0 +1,72 @@
+---
+layout: default
+num: '15a · Funktion auslagern'
+meta: 'Block 4 · 04_module/ · from netutils import …'
+---
+
+<div class="page-label">Block 4 · Funktion auslagern</div>
+
+# Eine Funktion in ihre <span class="accent">eigene Datei</span><span class="dot">.</span>
+
+<div class="vn">
+
+  <div class="vn-col">
+    <div class="vn-tag vorher">Vorher · alles in main.py</div>
+
+```python
+# main.py — Funktion UND Ablauf in einer Datei
+def is_private(ip: str) -> bool:
+    return ip.startswith(("10.", "192.168.", "172.16."))
+
+for ip in ["10.0.1.5", "8.8.8.8"]:
+    print(ip, "privat" if is_private(ip) else "öffentlich")
+```
+
+  </div>
+
+  <div class="vn-col" v-click>
+    <div class="vn-tag nachher">Nachher · Werkzeug im Modul, Ablauf in main</div>
+
+```python
+# netutils.py — der Werkzeugkasten
+def is_private(ip: str) -> bool:
+    return ip.startswith(("10.", "192.168.", "172.16."))
+```
+
+```python
+# main.py — holt das Werkzeug herein
+from netutils import is_private
+
+for ip in ["10.0.1.5", "8.8.8.8"]:
+    print(ip, "privat" if is_private(ip) else "öffentlich")
+```
+
+  </div>
+
+</div>
+
+<div class="mantra" style="margin-top: 22px;">
+  <div class="label">import-Regel</div>
+  <div class="text"><span class="mono">from netutils import is_private</span> — Dateiname <strong>ohne</strong> <span class="mono">.py</span>, Funktionsname genau wie definiert. Beide Dateien im selben Ordner.</div>
+</div>
+
+<style scoped>
+.vn { display: grid; grid-template-columns: 1fr 1fr; gap: 30px; margin-top: 24px; align-items: start; }
+.vn-tag { font-family: var(--font-mono); font-size: 15px; font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase; margin-bottom: 12px; }
+.vn-tag.vorher { color: #C0392B; }
+.vn-tag.nachher { color: var(--accent); }
+.vn .slidev-code { font-size: 17px !important; padding: 20px !important; }
+.vn-col > .slidev-code + .slidev-code { margin-top: 14px; }
+</style>
+
+<!--
+Das ist die direkte Antwort auf die Frage „wie teile ich Funktionen auf mehrere Dateien auf?".
+Links: alles steckt in main.py — funktioniert, wird aber schnell unübersichtlich und die Funktion
+lässt sich in keinem anderen Skript nutzen. Per Klick die rechte Seite aufdecken: die Funktion
+wandert unverändert nach netutils.py (das Modul aus der vorigen Slide). main.py holt sie mit
+'from netutils import is_private' herein und bleibt schlank — nur noch der Ablauf. Wichtig für
+Einsteiger und der häufigste Stolperstein: beim import den DATEINAMEN ohne .py schreiben
+(netutils, nicht netutils.py), der Funktionsname muss exakt passen (Groß/Klein), und beide
+Dateien müssen im selben Ordner liegen, sonst gibt es ModuleNotFoundError. Faustregel wie bei
+Funktionen, nur eine Ebene höher: was woanders wiederverwendbar ist, kommt in ein eigenes Modul.
+-->

--- a/presentations/python-netzwerk/slides/41b_anatomie.md
+++ b/presentations/python-netzwerk/slides/41b_anatomie.md
@@ -1,0 +1,60 @@
+---
+layout: default
+num: '15b · Anatomie eines Skripts'
+meta: 'Block 4 · Aufbau · if __name__ == "__main__"'
+---
+
+<div class="page-label">Block 4 · Anatomie eines Skripts</div>
+
+# Jedes Skript hat die <span class="accent">gleiche Ordnung</span><span class="dot">.</span>
+
+<div style="display: grid; grid-template-columns: 1.15fr 0.85fr; gap: 40px; margin-top: 24px; align-items: start;">
+
+<div>
+
+```python {1-2|4-5|7-10|12-13|all}
+# 1 · Imports — was das Skript braucht
+from netutils import is_private
+
+# 2 · Konstanten — feste Werte, GROSS geschrieben
+HOSTS = ["10.0.1.5", "8.8.8.8"]
+
+# 3 · Funktionen — die Bausteine (Prozeduren)
+def main() -> None:
+    for ip in HOSTS:
+        print(ip, "privat" if is_private(ip) else "öffentlich")
+
+# 4 · Startpunkt — nur bei direktem Ausführen
+if __name__ == "__main__":
+    main()
+```
+
+</div>
+
+<div>
+<ul style="margin: 0; padding: 0; list-style: none; display: grid; gap: 16px; font-size: 21px; line-height: 1.4;">
+  <li><span class="accent" style="font-weight: 600;">1 Imports</span> immer oben — man sieht sofort die Abhängigkeiten.</li>
+  <li><span class="accent" style="font-weight: 600;">2 Konstanten</span> darunter, <span class="mono">GROSS</span> geschrieben.</li>
+  <li><span class="accent" style="font-weight: 600;">3 Funktionen</span> definieren, was passiert — noch nichts läuft.</li>
+  <li><span class="accent" style="font-weight: 600;">4 Der Guard</span> startet <span class="mono">main()</span> nur beim direkten Aufruf.</li>
+</ul>
+
+<div class="mantra" style="margin-top: 24px;">
+  <div class="label"><span class="mono">if __name__ == "__main__":</span></div>
+  <div class="text"><span class="mono">python main.py</span> → läuft. <span class="mono">from main import …</span> → läuft <strong>nicht</strong> automatisch mit.</div>
+</div>
+</div>
+
+</div>
+
+<!--
+Diese Slide beantwortet „Aufbau / Struktur eines Programms". Kernbotschaft: fast jedes gute
+Python-Skript hat dieselben vier Abschnitte in dieser Reihenfolge — Imports, Konstanten,
+Funktionen, Startpunkt. Geh die Highlights durch. Wichtig zu betonen: Funktionen zu DEFINIEREN
+führt noch nichts aus; erst der Aufruf am Ende startet das Programm. Der Clou ist der Guard
+if __name__ == "__main__". Erkläre ihn an der vorigen Slide: netutils.py wollen wir importieren,
+ohne dass sein Code losläuft. Python setzt die Variable __name__ auf "__main__", WENN die Datei
+direkt gestartet wird (python main.py) — und auf den Modulnamen, wenn sie importiert wird. So
+kann dieselbe Datei sowohl als Programm laufen als auch als Werkzeugkasten importiert werden,
+ohne Nebenwirkungen. Das ist DER Standard-Rahmen; ab jetzt bauen wir jedes Skript so.
+-->

--- a/presentations/python-netzwerk/style.css
+++ b/presentations/python-netzwerk/style.css
@@ -13,11 +13,17 @@
 }
 
 :root {
-  --accent: #8b5cf6;
-  --accent-soft: rgba(139, 92, 246, 0.18);
+  /* Python-Palette — Blau als Haupt-Akzent, Gelb als Signal-Zweitfarbe.
+     --accent  : dunkles Python-Blau, lesbar auf hellem Hintergrund
+     --accent-bright : helles Python-Blau, für dunkle Flächen (Cover/deep)
+     --accent-yellow : Python-Gelb, nur auf dunklen Flächen einsetzen */
+  --accent: #306998;
+  --accent-soft: rgba(48, 105, 152, 0.18);
+  --accent-bright: #4b8bbe;
+  --accent-yellow: #ffd43b;
 
   --bg: #f7f6f3;
-  --bg-deep: #0e1020;
+  --bg-deep: #13243d;
 
   --fg: #111322;
   --fg-muted: rgba(17, 19, 34, 0.72);
@@ -28,7 +34,7 @@
   --grid-line: rgba(255, 255, 255, 0.06);
 
   --surface: rgba(17, 19, 34, 0.04);
-  --surface-accent: rgba(139, 92, 246, 0.08);
+  --surface-accent: rgba(48, 105, 152, 0.08);
 
   --font-sans: "Inter", system-ui, -apple-system, sans-serif;
   --font-mono: "JetBrains Mono", ui-monospace, monospace;
@@ -37,13 +43,14 @@
 /* Sections rendered against --bg-deep need light foregrounds. */
 .deep,
 .slidev-layout.deep {
+  --accent: var(--accent-bright);
   --fg: #f1f3fb;
   --fg-muted: rgba(241, 243, 251, 0.74);
   --fg-faint: rgba(241, 243, 251, 0.50);
   --rule: rgba(241, 243, 251, 0.14);
   --rule-strong: rgba(241, 243, 251, 0.30);
   --surface: rgba(255, 255, 255, 0.04);
-  --surface-accent: rgba(139, 92, 246, 0.18);
+  --surface-accent: rgba(75, 139, 190, 0.18);
   background: var(--bg-deep);
   color: var(--fg);
 }
@@ -274,7 +281,7 @@ body > div.fixed.left-0.right-0.top-0.z-20 {
 .speaker-bar .sp-active .sp-dot {
   width: 10px; height: 10px; border-radius: 50%;
   background: var(--accent);
-  box-shadow: 0 0 0 4px rgba(139, 92, 246, 0.18);
+  box-shadow: 0 0 0 4px rgba(48, 105, 152, 0.18);
   animation: speaker-pulse 1.6s ease-in-out infinite;
 }
 .speaker-bar .sp-passive {
@@ -284,15 +291,15 @@ body > div.fixed.left-0.right-0.top-0.z-20 {
   content: '·'; margin-right: 18px; color: var(--fg-faint);
 }
 @keyframes speaker-pulse {
-  0%, 100% { box-shadow: 0 0 0 4px rgba(139, 92, 246, 0.18); }
-  50%      { box-shadow: 0 0 0 8px rgba(139, 92, 246, 0.06); }
+  0%, 100% { box-shadow: 0 0 0 4px rgba(48, 105, 152, 0.18); }
+  50%      { box-shadow: 0 0 0 8px rgba(48, 105, 152, 0.06); }
 }
 
 /* Flipchart-Modus banner — konsistenter Anzeiger auf allen Flipchart-Slides.
    Slot 6 (Bereitsteller) und Slot 7 (Plattform-Team) überschreiben die Akzent-Farbe
    per .is-bereitsteller / .is-plattform Scope in ihren jeweiligen Files. */
 .slide-flipchart {
-  background: linear-gradient(to bottom, rgba(139,92,246,0.04), transparent 20%);
+  background: linear-gradient(to bottom, rgba(48,105,152,0.04), transparent 20%);
 }
 
 .flipchart-banner {
@@ -605,6 +612,7 @@ body > div.fixed.left-0.right-0.top-0.z-20 {
 
 .slide-cover,
 .slidev-layout.slide-cover {
+  --accent: var(--accent-bright);
   padding: 0 !important;
   background: var(--bg-deep) !important;
   color: #f1f3fb;
@@ -642,7 +650,8 @@ body > div.fixed.left-0.right-0.top-0.z-20 {
   text-wrap: balance;
 }
 .slide-cover h1 .accent { color: var(--accent); }
-.slide-cover h1 .dot    { color: var(--accent); }
+.slide-cover h1 .dot    { color: var(--accent-yellow); }
+.slide-cover .kicker    { color: var(--accent-yellow); }
 
 .slide-cover .sub {
   position: relative; z-index: 1;
@@ -659,7 +668,7 @@ body > div.fixed.left-0.right-0.top-0.z-20 {
    ================================================================ */
 
 .is-exercise.slidev-layout {
-  background: linear-gradient(to bottom, rgba(139, 92, 246, 0.05), transparent 22%);
+  background: linear-gradient(to bottom, rgba(48, 105, 152, 0.05), transparent 22%);
 }
 
 .exercise-badge {

--- a/presentations/python-netzwerk/style.css
+++ b/presentations/python-netzwerk/style.css
@@ -139,6 +139,7 @@ pre, code { font-family: var(--font-mono); }
 .slidev-code {
   background: var(--bg-deep) !important;
   border: 1px solid var(--rule);
+  border-left: 3px solid rgba(255, 212, 59, 0.55);
   border-radius: 12px;
   padding: 28px !important;
   font-size: 22px !important;
@@ -240,8 +241,9 @@ body > div.fixed.left-0.right-0.top-0.z-20 {
   color: var(--fg); margin-bottom: 24px;
 }
 .page-label::before {
-  content: ''; width: 36px; height: 2px;
-  background: var(--accent); display: block;
+  content: ''; width: 44px; height: 3px; border-radius: 1px;
+  background: linear-gradient(90deg, var(--accent) 60%, var(--accent-yellow) 60%);
+  display: block;
 }
 
 /* Headline accent â€” wrap a word in <span class="accent"> in the h1 */
@@ -249,6 +251,9 @@ body > div.fixed.left-0.right-0.top-0.z-20 {
 
 /* Trailing period dot in headlines as accent â€” wrap in <span class="dot">.</span> */
 .slidev-layout h1 .dot { color: var(--accent); }
+
+/* Auf dunklen Flaechen (Cover, Section-Divider) ist der Punkt gelb - Python-Zweitfarbe */
+.deep h1 .dot { color: var(--accent-yellow); }
 
 /* Mantra / "Merke" callout â€” accent border + tinted surface */
 .mantra {


### PR DESCRIPTION
## Was ändert sich

Erweiterung und Re-Theming des Python-Einsteiger-Decks fürs Netzwerkteam (`presentations/python-netzwerk`).

### Neue Slides
- **Vorstellungsrunde** (`00e`) direkt nach dem Cover — Kennenlern-Runde mit vier Fragen (Rolle, Vorerfahrung, Automatisierungs-Wunsch, Tagesziel).
- **Bash vs. Python** (`00c2`) im Intro — dieselbe Aufgabe (Geräte mit hoher CPU-Last aus einer JSON-API) in Bash vs. Python. Fair gehalten (Bash mit `jq`, kein Strawman), Fazit als Faustregel.
- **Block 4:** „Funktion auslagern" (`41a`, `main.py` → `netutils.py`) und „Anatomie eines Skripts" (`41b`, `if __name__ == "__main__"`).

### Umgebaut
- Datentypen-Slide in zwei aufgeteilt — **Einzelwerte** (`str/int/float/bool`) und **Sammlungen** (`list/dict`) — mit deutlich größerem, lesbarem Code (26px).

### Theme
- Umstellung von Violett auf die **Python-Farben**: Blau als Haupt-Akzent (`#306998` hell / `#4B8BBE` auf dunkel), Python-Gelb (`#FFD43B`) als Zweitfarbe auf dunklen Flächen.
- Gelb-Akzente: Punkt auf Cover + Section-Dividern, gelbe Kante an Code-Blöcken, zweifarbiger Page-Label-Balken. Gelb bewusst nie auf hellem Text (Kontrast).

## Test
Deck rendert fehlerfrei über das `stuttgart-things/dagger/slidev`-Modul; alle neuen Slides per Screenshot geprüft (Cover, Divider, Intro-Vergleich, Datentypen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)