### PR TITLE
Deck: GitLab Pages CI + idea notes (draft for later)

### DIFF
--- a/presentations/python-netzwerk/.gitlab-ci.yml
+++ b/presentations/python-netzwerk/.gitlab-ci.yml
@@ -1,0 +1,32 @@
+# GitLab Pages deploy für das Slidev-Deck.
+#
+# Annahme: dieses Deck liegt im ROOT des GitLab-Repos.
+# Liegt es in einem Unterordner, siehe Hinweis unten (cd + --out-Pfad).
+#
+# Ergebnis-URL:  https://<namespace>.gitlab.io/<projekt>/
+# Der --base-Pfad MUSS dazu passen, sonst laden CSS/JS/Assets nicht (404).
+
+image: node:20
+
+pages:
+  stage: deploy
+  script:
+    # Kein package.json/node_modules im Repo -> hier frisch installieren.
+    - npm init -y
+    - npm install -D @slidev/cli @slidev/theme-default @slidev/types
+    # Projekt-Pages liegen unter /<projekt>/ -> base entsprechend setzen.
+    # Für ein Root-Pages-Repo (<namespace>.gitlab.io) stattdessen: --base "/"
+    - npx slidev build slides.md --base "/$CI_PROJECT_NAME/" --out public
+  artifacts:
+    paths:
+      - public          # GitLab Pages liefert ausschließlich diesen Ordner aus
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+
+# --- Deck in einem Unterordner? ------------------------------------------
+# Dann im script vor dem Build hineinwechseln und public ins Repo-Root schreiben:
+#   - cd presentations/python-netzwerk
+#   - npm init -y
+#   - npm install -D @slidev/cli @slidev/theme-default @slidev/types
+#   - npx slidev build slides.md --base "/$CI_PROJECT_NAME/" --out ../../public
+# artifacts.paths bleibt "public" (relativ zum Repo-Root).

--- a/presentations/python-netzwerk/GITLAB-PAGES.md
+++ b/presentations/python-netzwerk/GITLAB-PAGES.md
@@ -1,0 +1,52 @@
+# Idee: Deck über GitLab Pages ausliefern
+
+Notiz für später — das Slidev-Deck als statische Website auf GitLab Pages hosten,
+damit Teilnehmer:innen die Slides einfach per Link im Browser ansehen können
+(ohne code-server, ohne lokalen `dagger`/`slidev serve`).
+
+## Warum das funktioniert
+
+`slidev build` erzeugt eine **rein statische Site** (HTML/JS/CSS) — genau das, was
+GitLab Pages ausliefert. Kein Server, kein Browser/Playwright nötig (das braucht nur
+der PDF-Export). Der Pages-Build ist damit leicht und schnell.
+
+## Bausteine
+
+- **`.gitlab-ci.yml`** (liegt im Deck-Ordner) — Job `pages`, der Slidev installiert,
+  nach `public/` baut und von GitLab automatisch deployt wird.
+- **Output-Ordner `public/`** — GitLab Pages liefert ausschließlich diesen Ordner aus.
+- **`--base`-Pfad** — muss zur Pages-URL passen.
+
+## Ablauf (Kurzform)
+
+1. Deck-Inhalt in ein GitLab-Repo laden (am einfachsten: dieser Ordner als eigenes
+   Repo, Deck im Root → `.gitlab-ci.yml` liegt direkt richtig).
+2. Push auf den Default-Branch → Pipeline baut + deployt.
+3. Ergebnis unter `https://<namespace>.gitlab.io/<projekt>/`
+   (die genaue URL steht im Pipeline-Log).
+
+## Die zwei Stolpersteine
+
+| Thema | Problem | Lösung (in der CI gesetzt) |
+|-------|---------|----------------------------|
+| **Base-Pfad** | Projekt-Pages liegen unter `/<projekt>/`; ohne passenden `--base` laden Assets nicht (404, weiße Seite). | `--base "/$CI_PROJECT_NAME/"` · Root-Pages-Repo (`<namespace>.gitlab.io`) → `--base "/"` |
+| **Keine Deps im Repo** | Es gibt bewusst kein `package.json`/`node_modules` (wird sonst im Container erzeugt). | CI installiert frisch: `@slidev/cli`, `@slidev/theme-default`, `@slidev/types`. `setup/main.ts` + `layouts/` + `style.css` ziehen automatisch mit. |
+
+## Deck in einem Unterordner?
+
+Falls das Deck **nicht** im Repo-Root liegt: in der `.gitlab-ci.yml` vor dem Build
+`cd <pfad>` und mit `--out ../../public` ins Repo-Root schreiben (auskommentierte
+Variante ist in der Datei enthalten). `artifacts.paths` bleibt `public`.
+
+## Alternative: GitHub Pages
+
+Dasselbe Prinzip läuft auf **GitHub Pages** mit einem GitHub-Actions-Workflow
+(`actions/deploy-pages`) — gleicher `slidev build`, gleicher `--base`-Trick
+(dort `/<repo>/`). Das gehen wir separat an.
+
+## Offene To-dos
+
+- [ ] Ziel klären: eigenes GitLab-Repo vs. Unterordner vs. GitHub Pages.
+- [ ] Platzhalter im Deck prüfen (URL/Passwort/Proxy) — nichts Internes öffentlich stellen.
+- [ ] Sichtbarkeit/Zugriff der Pages-Site festlegen (öffentlich vs. intern).
+- [ ] Optional: PDF-Handout als zusätzliches CI-Artefakt.


### PR DESCRIPTION
## Was ist drin

Vorbereitung, um das Slidev-Deck (`presentations/python-netzwerk`) später als statische Website zu hosten. **Noch nicht aktiv** — wir gehen das Deployment separat an.

- **`.gitlab-ci.yml`** — `pages`-Job: installiert Slidev, baut nach `public/`, GitLab deployt automatisch. Enthält den `--base`-Pfad-Fix für Projekt-Pages und eine auskommentierte Unterordner-Variante.
- **`GITLAB-PAGES.md`** — die Idee als Notiz: warum ein `slidev build` für Pages reicht, die zwei Stolpersteine (Base-Pfad, fehlende Deps im Repo), GitHub-Pages-Alternative und offene To-dos.

## Kontext

`slidev build` erzeugt eine rein statische Site (kein Server/Browser nötig), die GitLab **oder** GitHub Pages ausliefern kann. Style/Layouts/`setup/main.ts` ziehen beim Build automatisch mit.

## Hinweis

Die `.gitlab-ci.yml` ist im GitHub-Repo wirkungslos (wird ignoriert). Nächster Schritt wird separat entschieden: eigenes GitLab-Repo, Unterordner, oder direkt GitHub Pages via Actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)